### PR TITLE
Add additional attributes to CalendarItem

### DIFF
--- a/lib/ews/types/calendar_item.rb
+++ b/lib/ews/types/calendar_item.rb
@@ -16,14 +16,16 @@ module Viewpoint::EWS::Types
       location:     [:location, :text],
       all_day?:     [:is_all_day_event, :text],
       legacy_free_busy_status: [:legacy_free_busy_status, :text],
+      calendar_item_type: [:calendar_item_type, :text],
       my_response_type:   [:my_response_type, :text],
       organizer: [:organizer, :elems, 0, :mailbox, :elems],
-      optional_attendees: [:optional_attendees, :elems ],
-      required_attendees: [:required_attendees, :elems ],
+      optional_attendees: [:optional_attendees, :elems],
+      required_attendees: [:required_attendees, :elems],
+      responses:  [:response_objects, :elems],
       recurrence: [:recurrence, :elems ],
-      deleted_occurrences: [:deleted_occurrences, :elems ],
-      modified_occurrences: [:modified_occurrences, :elems ]
-   }
+      deleted_occurrences: [:deleted_occurrences, :elems],
+      modified_occurrences: [:modified_occurrences, :elems]
+    }
 
     CALENDAR_ITEM_KEY_TYPES = {
       start:        ->(str){DateTime.parse(str)},


### PR DESCRIPTION
New attributes:

1. `:calendar_item_type`. 
Might be one of: `Single`, `RecurringMaster`, `Occurrence`.

2. `:responses`
Example:
```
{:response_objects=>{:elems=>[
    {:accept_item=>{}}, 
    {:tentatively_accept_item=>{}}, 
    {:decline_item=>{}}, 
    {:reply_to_item=>{}}, 
    {:reply_all_to_item=>{}},
    {:forward_item=>{}}
]}}
```