### PR TITLE
Handle subscription related errors

### DIFF
--- a/lib/ews/soap/responses/get_streaming_events_response_message.rb
+++ b/lib/ews/soap/responses/get_streaming_events_response_message.rb
@@ -31,6 +31,11 @@ module Viewpoint::EWS::SOAP
       @notifications = n.nil? ? [] : parse_notifications(n)
     end
 
+    def error_subscription_ids
+      e = safe_hash_access message, [:elems, :error_subscription_ids, :elems]
+      e.nil? ? [] : e.map {|e| safe_hash_access(e, [:subscription_id, :text])}
+    end
+
     private
 
     def parse_notifications(notifications)


### PR DESCRIPTION
Handle a response with error when a user tries to get events for a subscription that cannot be found. The subscription might have expired, the EWS process might have been restarted, or an invalid subscription was passed in.
