### PR TITLE
Handle HTTP redirect when sending requests to EWS

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -110,8 +110,10 @@ class Viewpoint::EWS::Connection
     when 200
       resp.body
     when 302
-      # @todo redirect
-      raise Errors::UnhandledResponseError.new("Unhandled HTTP Redirect", resp)
+      redirect_url = @httpcli.default_redirect_uri_callback(URI(@endpoint), resp).to_s rescue nil
+      return raise Errors::UnhandledResponseError.new("Unhandled HTTP Redirect", resp) unless redirect_url
+
+      check_response @httpcli.get(redirect_url)
     when 401
       raise Errors::UnauthorizedResponseError.new("Unauthorized request", resp)
     when 500


### PR DESCRIPTION
Follow HTTP redirect and get response from redirected URL. 