### PR TITLE
Affinity

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -72,13 +72,15 @@ class Viewpoint::EWS::Connection
     @log.debug <<-EOF.gsub(/^ {6}/, '')
       Received SOAP Response:
       ----------------
-      #{respmsg.headers.to_a.map{ |a| a.join(": ") }.join("\n")}
+      #{respmsg.header.all.to_a.map{ |a| a.join(": ") }.join("\n")}
       ----------------
       #{Nokogiri::XML(respmsg.body).to_xml}
       ----------------
     EOF
     content = opts[:raw_response] ? respmsg.body : ews.parse_soap_response(respmsg.body, opts)
-    opts[:return_headers] ? { headers: respmsg.headers, content: content } : content
+    opts[:return_headers] ? { headers: respmsg.header.all,
+                              cookies: respmsg.cookies.map { |c| { c.name => c.value } }.reduce(&:merge),
+                              content: content } : content
   end
 
   # Send a GET to the web service

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -78,9 +78,11 @@ class Viewpoint::EWS::Connection
       ----------------
     EOF
     content = opts[:raw_response] ? respmsg.body : ews.parse_soap_response(respmsg.body, opts)
-    opts[:return_headers] ? { headers: respmsg.header.all,
-                              cookies: respmsg.cookies.map { |c| { c.name => c.value } }.reduce(&:merge),
-                              content: content } : content
+    opts[:return_headers] ? {
+        headers: respmsg.header.all,
+        cookies: (respmsg.cookies.map { |c| { c.name => c.value } }.reduce(&:merge) if respmsg.cookies),
+        content: content
+    } : content
   end
 
   # Send a GET to the web service

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -68,7 +68,7 @@ class Viewpoint::EWS::Connection
   # @param soapmsg [String]
   # @param opts [Hash] misc opts for handling the Response
   def dispatch(ews, soapmsg, opts)
-    respmsg = post(soapmsg)
+    respmsg = post(soapmsg, opts)
     @log.debug <<-EOF.gsub(/^ {6}/, '')
       Received SOAP Response:
       ----------------
@@ -88,18 +88,21 @@ class Viewpoint::EWS::Connection
   # Send a POST to the web service
   # @return [String] If the request is successful (200) it returns the body of
   #   the response.
-  def post(xmldoc)
-    headers = {'Content-Type' => 'text/xml'}
+  def post(xmldoc, opts = {})
+    headers = opts[:headers] || {}
+    headers = headers.merge({'Content-Type' => 'text/xml'})
+    puts "Headers: #{headers}"
     check_response( @httpcli.post(@endpoint, xmldoc, headers) )
   end
 
   # Send an asynchronous POST request to the web service
   # @return HTTPClient::Connection instance
-  def post_async(xmldoc)
+  def post_async(xmldoc, opts = {})
     # Client need to be authenticated first.
     # Related issue: https://github.com/nahi/httpclient/issues/181
     authenticate
-    headers  = {'Content-Type' => 'text/xml'}
+    headers = opts[:headers] || {}
+    headers = headers.merge({'Content-Type' => 'text/xml'})
     @httpcli.post_async(@endpoint, xmldoc, headers)
   end
 

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -78,7 +78,7 @@ class Viewpoint::EWS::Connection
       ----------------
     EOF
     content = opts[:raw_response] ? respmsg.body : ews.parse_soap_response(respmsg.body, opts)
-    opts[:return_headers] ? [respmsg.headers, content] : content
+    opts[:return_headers] ? { headers: respmsg.headers, content: content } : content
   end
 
   # Send a GET to the web service

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -46,7 +46,7 @@ module Viewpoint::EWS::SOAP
     #         :event_types=> %w{NewMailEvent DeletedEvent},
     #       }},
     #       ]
-    def subscribe(subscriptions)
+    def subscribe(subscriptions, opts = {})
       req = build_soap! do |type, builder|
         if(type == :header)
         else
@@ -63,7 +63,7 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
+      do_soap_request(req, opts.merge({response_class: EwsResponse}))
     end
 
     # End a pull notification subscription.

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -109,7 +109,7 @@ module Viewpoint::EWS::SOAP
     # @param subscription_ids   [Array<String>] An array of Subscription identifiers
     # @param connection_timeout [Fixnum] Specifies the number of minutes to keep a connection open
     #        https://msdn.microsoft.com/EN-US/library/ff406137(v=exchg.150).aspx
-    def get_streaming_events(subscription_ids, connection_timeout = 30)
+    def get_streaming_events(subscription_ids, connection_timeout = 30, opts = {})
       req = build_soap! do |type, builder|
         if(type == :header)
         else
@@ -121,7 +121,7 @@ module Viewpoint::EWS::SOAP
         end
       end
 
-      do_async_soap_request(req)
+      do_async_soap_request(req, opts)
     end
 
     # ------- convenience methods ------- #

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -213,14 +213,14 @@ module Viewpoint::EWS::SOAP
     end
 
     # Send the SOAP request to the endpoint.
-    def do_async_soap_request(soapmsg)
+    def do_async_soap_request(soapmsg, opts = {})
       @log.debug <<-EOF.gsub(/^ {8}/, '')
         Sending SOAP Request:
         ----------------
         #{soapmsg}
         ----------------
       EOF
-      connection.post_async(soapmsg)
+      connection.post_async(soapmsg, opts)
     end
 
     # @param [String] response the SOAP response string

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -206,6 +206,8 @@ module Viewpoint::EWS::SOAP
       @log.debug <<-EOF.gsub(/^ {8}/, '')
         Sending SOAP Request:
         ----------------
+        #{opts[:headers] ? opts[:headers].to_a.map{ |a| a.join(": ") }.join("\n") : "No caller-specified headers"}
+        ----------------
         #{soapmsg}
         ----------------
       EOF
@@ -216,6 +218,8 @@ module Viewpoint::EWS::SOAP
     def do_async_soap_request(soapmsg, opts = {})
       @log.debug <<-EOF.gsub(/^ {8}/, '')
         Sending SOAP Request:
+        ----------------
+        #{opts[:headers] ? opts[:headers].to_a.map{ |a| a.join(": ") }.join("\n") : "No caller-specified headers"}
         ----------------
         #{soapmsg}
         ----------------

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -206,7 +206,8 @@ module Viewpoint::EWS::SOAP
       @log.debug <<-EOF.gsub(/^ {8}/, '')
         Sending SOAP Request:
         ----------------
-        #{opts[:headers] ? opts[:headers].to_a.map{ |a| a.join(": ") }.join("\n") : "No caller-specified headers"}
+        #{opts[:headers].present? ? opts[:headers].to_a.map{ |a| a.join(": ") }.join("\n") :
+          "No caller-specified headers"}
         ----------------
         #{soapmsg}
         ----------------
@@ -219,7 +220,8 @@ module Viewpoint::EWS::SOAP
       @log.debug <<-EOF.gsub(/^ {8}/, '')
         Sending SOAP Request:
         ----------------
-        #{opts[:headers] ? opts[:headers].to_a.map{ |a| a.join(": ") }.join("\n") : "No caller-specified headers"}
+        #{opts[:headers].present? ? opts[:headers].to_a.map{ |a| a.join(": ") }.join("\n") :
+          "No caller-specified headers"}
         ----------------
         #{soapmsg}
         ----------------


### PR DESCRIPTION
This change makes it possible to provide and retrieve headers (including cookies) when calling `subscribe` or `get_streaming_events`, which is required to manage affinity for streaming subscriptions, as implemented in https://github.com/Datacom/floormaps-rails/issues/408.

It should allow all existing methods to continue unaffected.